### PR TITLE
SS-971 Migrating CI pipelines to GitLab

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -11,7 +11,7 @@ jobs:
     - name: trigger Job
       uses: appleboy/gitlab-ci-action@master
       with:
-        url: "https://git.namics.com"
+        host: "https://git.namics.com"
         token: "5e9ddf072d14280269ffd48ad04243"
         project_id: 4757
         ref: "main"

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,0 +1,17 @@
+name: trigger gitlab job
+on: 
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: trigger Job
+      uses: appleboy/gitlab-ci-action@master
+      with:
+        url: "https://git.namics.com"
+        token: "5e9ddf072d14280269ffd48ad04243"
+        project_id: 4757
+        ref: "main"

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -11,7 +11,7 @@ jobs:
     - name: trigger Job
       uses: appleboy/gitlab-ci-action@master
       with:
-        host: "https://git.namics.com"
-        token: "5e9ddf072d14280269ffd48ad04243"
+        host: ${{ secrets.GIT_LAB_HOST }}
+        token: ${{ secrets.GIT_LAB_TOKEN }}
         project_id: 4757
         ref: "main"

--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -63,7 +63,7 @@
 
         <!-- Commands -->
         <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(NonInteractiveSwitch) $(RequireConsentSwitch) -solutionDir $(PaddedSolutionDir)</RestoreCommand>
-        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -Symbols -SymbolPackageFormat snupkg</BuildCommand>
 
         <!-- We need to ensure packages are restored prior to assembly resolve -->
         <BuildDependsOn Condition="$(RestorePackages) == 'true'">

--- a/packaging.targets
+++ b/packaging.targets
@@ -46,7 +46,7 @@
     <PackageOutputDir>$([System.IO.Path]::GetDirectoryName('$(ProjectDir)$(IntermediateOutputPath)'))</PackageOutputDir>
     <PackageSpec>$(ProjectPath.Replace('.csproj', '.nuspec'))</PackageSpec>
     <PackageOutput>$(ProjectName.Replace('.csproj', '')).*$(NugetPackageVersion).nupkg</PackageOutput>
-    <BuildCommandSolution Condition="'$(NugetPackageVersion)' != ''">$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -MSBuildVersion 14 $(IncludeReferencedProjects) -Symbols -SymbolPackageFormat snupkg -Properties "DependentVersion=$(NugetPackageVersion)" -Version "$(NugetPackageVersion)"</BuildCommandSolution>
+    <BuildCommandSolution Condition="'$(NugetPackageVersion)' != ''">$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -Symbols -SymbolPackageFormat snupkg -Properties "DependentVersion=$(NugetPackageVersion)" -Version "$(NugetPackageVersion)"</BuildCommandSolution>
     <PublishCommand>$(NuGetCommand) push "$(PackageOutputDir)\$(PackageOutput)" $(_NugetApiKey) -source "$(NugetRepository)"</PublishCommand>
   </PropertyGroup>
   <Target Name="PublishPackage" Condition="'$(PublishPackage)' == 'true'">

--- a/packaging.targets
+++ b/packaging.targets
@@ -46,7 +46,7 @@
     <PackageOutputDir>$([System.IO.Path]::GetDirectoryName('$(ProjectDir)$(IntermediateOutputPath)'))</PackageOutputDir>
     <PackageSpec>$(ProjectPath.Replace('.csproj', '.nuspec'))</PackageSpec>
     <PackageOutput>$(ProjectName.Replace('.csproj', '')).*$(NugetPackageVersion).nupkg</PackageOutput>
-    <BuildCommandSolution Condition="'$(NugetPackageVersion)' != ''">$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -MSBuildVersion 14 $(IncludeReferencedProjects) -SymbolPackageFormat snupkg -Properties "DependentVersion=$(NugetPackageVersion)" -Version "$(NugetPackageVersion)"</BuildCommandSolution>
+    <BuildCommandSolution Condition="'$(NugetPackageVersion)' != ''">$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -MSBuildVersion 14 $(IncludeReferencedProjects) -Symbols -SymbolPackageFormat snupkg -Properties "DependentVersion=$(NugetPackageVersion)" -Version "$(NugetPackageVersion)"</BuildCommandSolution>
     <PublishCommand>$(NuGetCommand) push "$(PackageOutputDir)\$(PackageOutput)" $(_NugetApiKey) -source "$(NugetRepository)"</PublishCommand>
   </PropertyGroup>
   <Target Name="PublishPackage" Condition="'$(PublishPackage)' == 'true'">

--- a/packaging.targets
+++ b/packaging.targets
@@ -46,7 +46,7 @@
     <PackageOutputDir>$([System.IO.Path]::GetDirectoryName('$(ProjectDir)$(IntermediateOutputPath)'))</PackageOutputDir>
     <PackageSpec>$(ProjectPath.Replace('.csproj', '.nuspec'))</PackageSpec>
     <PackageOutput>$(ProjectName.Replace('.csproj', '')).*$(NugetPackageVersion).nupkg</PackageOutput>
-    <BuildCommandSolution Condition="'$(NugetPackageVersion)' != ''">$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -MSBuildVersion 14 $(IncludeReferencedProjects) -Properties "DependentVersion=$(NugetPackageVersion)" -Version "$(NugetPackageVersion)"</BuildCommandSolution>
+    <BuildCommandSolution Condition="'$(NugetPackageVersion)' != ''">$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -MSBuildVersion 14 $(IncludeReferencedProjects) -SymbolPackageFormat snupkg -Properties "DependentVersion=$(NugetPackageVersion)" -Version "$(NugetPackageVersion)"</BuildCommandSolution>
     <PublishCommand>$(NuGetCommand) push "$(PackageOutputDir)\$(PackageOutput)" $(_NugetApiKey) -source "$(NugetRepository)"</PublishCommand>
   </PropertyGroup>
   <Target Name="PublishPackage" Condition="'$(PublishPackage)' == 'true'">


### PR DESCRIPTION
Change the symbols output to snupkg to the new nuget package extension
Remove the MSBuild version because the GitLab couldn't build with the version 14